### PR TITLE
Fix open graph image paths

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
         siteName: "www.garvv.me",
         images: [
             {
-                url: "./public/metadata.jpg",
+                url: "/metadata.jpg",
                 width: 1200,
                 height: 630,
                 alt: "TRAZHUB - Designer",
@@ -48,7 +48,7 @@ export const metadata: Metadata = {
       "Student, currently studying at Sharda University Noida. Focused on immersive experiences, studying in Ghaziabad, India.",
         creator: "Garv",
         creatorId: "0000000000",
-        images: ["./public/okay1.png"],
+        images: ["/okay1.png"],
     },
     robots: {
         index: true,


### PR DESCRIPTION
## Summary
- correct incorrect Open Graph image URLs in `app/layout.tsx`

## Testing
- `npx tsc --noEmit` *(fails: cannot find type definition for 'bun-types')*

------
https://chatgpt.com/codex/tasks/task_e_6850532abbe48325bb3618325a01a7a4